### PR TITLE
IE Fix

### DIFF
--- a/js/ngjs-color-picker.js
+++ b/js/ngjs-color-picker.js
@@ -37,7 +37,7 @@ angular.module('ngjsColorPicker', [])
                         blRound: $index==(colors.length-options.columns)&&columnRound\
                         }"\
                         ng-click="pick(color)"\
-                        style="background-color:{{color}};"\
+                        ng-attr-style="background-color:{{color}};"\
                         ng-style="css">\
                         </li></ul>',
             link: function (scope, element, attr) {


### PR DESCRIPTION
In the template, made the `style` attribute be `ng-attr-style`, so that it would work with Internet Explorer.
Otherwise, it wouldn't render the background color.
