### PR TITLE
Fixing background color in IE

### DIFF
--- a/js/ngjs-color-picker.js
+++ b/js/ngjs-color-picker.js
@@ -38,7 +38,7 @@ angular.module('ngjsColorPicker', [])
                         }"\
                         ng-click="pick(color)"\
                         ng-attr-style="background-color:{{color}};"\
-                        ng-style="css">\
+                        ng-style="getCss(color)">\
                         </li></ul>',
             link: function (scope, element, attr) {
 
@@ -140,6 +140,12 @@ angular.module('ngjsColorPicker', [])
                     var num = parseInt(color.slice(1),16), amt = Math.round(2.55 * percent), R = (num >> 16) + amt, G = (num >> 8 & 0x00FF) + amt, B = (num & 0x0000FF) + amt;
                     return "#" + (0x1000000 + (R<255?R<1?0:R:255)*0x10000 + (G<255?G<1?0:G:255)*0x100 + (B<255?B<1?0:B:255)).toString(16).slice(1);
                 }
+
+                // Returns the existing css, but setting its background property to the passed color
+                scope.getCss = function (color) {
+                    scope.css.background = color;
+		    return scope.css;
+                };
 
                 // Pick a color from the view
                 scope.pick = function (color) {


### PR DESCRIPTION
Hey, buddy.

It seems there was an issue on IE 10 (the version I noticed the issue) with the background color not being applied to the color selectors. I believe it's fixed. Please, take a look.
![background-ie](https://cloud.githubusercontent.com/assets/8137280/15618713/f9ad0bc6-2425-11e6-9590-b748243729f8.png)

Thanks,
Jodevan.
