### PR TITLE
customColors moved and now work

### DIFF
--- a/source/ngjs-color-picker.js
+++ b/source/ngjs-color-picker.js
@@ -251,7 +251,6 @@ angular.module('ngjsColorPicker', [])
         return {
             scope: {
                 selectedColor: '=?',
-                customColors: '=?',
                 options: '=?',
                 gradient: '=?'
             },

--- a/source/ngjs-color-picker.js
+++ b/source/ngjs-color-picker.js
@@ -143,8 +143,8 @@ angular.module('ngjsColorPicker', [])
         };
 
         var setColors = function(scope) {
-            if (!!scope.customColors) {
-                scope.colors = scope.customColors;
+            if (!!scope.options.customColors) {
+                scope.colors = scope.options.customColors;
             } else if (scope.options && !!scope.options.randomColors) {
                 if (scope.options.randomColors > 0) {
                     scope.colors = [];


### PR DESCRIPTION
Hi,

I tried this module, it is a great work. Thank you for sharing this module.

When I tried to use `customColors`, it was not working. I looked in the `setColor` function, the `scope.customColors` was always `undefined`. I did not look any further because I am thinking customColors could be an option rather than an independent attribute.

So, there is the commits with customColors moved.
Please, update the GitHub page : you have to move customColors in options if you accept the PR.